### PR TITLE
Fix WCAG issues in demo certificate

### DIFF
--- a/src/templates/govtech-demo-cert/certificate.tsx
+++ b/src/templates/govtech-demo-cert/certificate.tsx
@@ -125,7 +125,7 @@ export const CertificateTemplate: FunctionComponent<TemplateProps<GovtechOpencer
 }) => (
   <Page certificateBg={`url('${certificateBg}')`} className="p-4">
     <PrintWatermark />
-    <main className="text-center">
+    <section className="text-center">
       <div className="spacer">
         <img src={mainLogo} className="img-fluid logo-oc" alt="OpenCerts Logo" />
       </div>
@@ -143,8 +143,8 @@ export const CertificateTemplate: FunctionComponent<TemplateProps<GovtechOpencer
         <i>certification through training administered by</i>
       </div>
       <img className="img-fluid logo-gt" src={logo} alt="Govtech Logo" />
-    </main>
-    <footer>
+    </section>
+    <section>
       <div className="row align-items-center">
         <div className="col">
           <div className="text-center text-sm">
@@ -167,6 +167,6 @@ export const CertificateTemplate: FunctionComponent<TemplateProps<GovtechOpencer
           <div className="text-sm text-right">Dated {format(document.issuedOn, "DD/MM/YYYY")}</div>
         </div>
       </div>
-    </footer>
+    </section>
   </Page>
 );


### PR DESCRIPTION
### Issue
This cert is rendered in an iframe of opencert.io renderer.  It has existing main and footer tags which  [AxE accessibility plugin ](https://chrome.google.com/webstore/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd) refers as landmarks being [not unique](https://dequeuniversity.com/rules/axe/4.4/landmark-unique?application=AxeChrome). (each page should just have 1 main and 1 footer html tag)

### What is this PR fixing?
Replace main and footer tags with section tag.  


